### PR TITLE
Update .golangci.yml to replace exportloopref with copyloopvar

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,15 +19,15 @@ linters:
   enable:
     - asciicheck
     - bodyclose  # Temporarily disabled.
+    - copyloopvar
     #- depguard
     - dogsled
     #- errcheck  # Temporarily disabled.
     - errorlint
     - exhaustive
-    - exportloopref
     - gci
     #- gochecknoinits  # Temporarily disabled.
-    #- gocognit # Temporarily disabled.
+    #- gocognit  # Temporarily disabled.
     - goconst
     - gocritic
     - gocyclo
@@ -139,4 +139,3 @@ linters-settings:
       - ptrToRefParam
       - typeUnparen
       - unnecessaryBlock
-


### PR DESCRIPTION
Addresses issue: #

Changes proposed in this pull request:

- Change 1
- Change 2
- Change 3

## Summary by Sourcery

Enhancements:
- Replaced the `exportloopref` linter with `copyloopvar` in the `.golangci.yml` configuration file to improve loop variable handling.